### PR TITLE
LINE Notifyサービス終了に伴う代替ライブラリの推奨追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 > [!WARNING]
 > このリポジトリはLINE Notifyのサービス終了に伴い、アーカイブされます。  
 > This repository will be archived due to the closure of the LINE Notify service.
->
+> 
 > > https://notify-bot.line.me/closing-announce
+>
+> **代替ライブラリとして [miso-develop/linebot-notify](https://github.com/miso-develop/linebot-notify) がおすすめです。LINE Bot Messaging APIを使用した通知が可能です。**
 
 LINE Notify APIのNode.jsライブラリです。
 
 
 <a href="https://www.buymeacoffee.com/mitsuoka0423"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=☕&slug=mitsuoka0423&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" width="150px" /></a>
 >
-> 開発の励みになりますので、使ってみて便利でしたらコーヒーをご馳走してください
+> 開発の励みになりますので、使ってみて良かったらコーヒーをご馳走してください
 
 ## Install
 
@@ -21,7 +23,7 @@ $ npm install line-notify-nodejs
 
 ## How to Use
 
-1. 下記ページでトークンを発行する
+1. 下記ページでトークンを実行する
     - https://notify-bot.line.me/my/
 
 2. トークンを使用して通知を送信する


### PR DESCRIPTION
LINE Notifyサービス終了に伴い、代替として利用可能なライブラリ「linebot-notify」をREADMEに追加しました。

linebot-notifyは、LINE Bot Messaging APIを使って簡単に通知を送信できるライブラリで、LINE Notifyの代替として活用できます。

READMEの冒頭に代替ライブラリへの案内を追加しました。